### PR TITLE
Fix docstrings in tests

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -257,7 +257,7 @@ class TestRectangles:
         assert res.dtype == np.float32
 
     def test_full_intensity(self):
-        """ Test that there exists a pixel with a full intensity = 1."""
+        """Test that there exists a pixel with a full intensity = 1."""
 
         shape = (50, 100)
         res = rectangles(10, shape, (20, 30), (10, 50), n_levels=4)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -635,7 +635,7 @@ class TestImageSimilarityMetrics:
 
     @pytest.mark.parametrize("metric", list(ALL_IMG_METRICS.keys()))
     def test_incorrect_dtype(self, img_grayscale_float, metric):
-        """Test that the type of inputs images has to be float32. If not, raises an exception """
+        """Test that the type of inputs images has to be float32. If not, raises an exception"""
 
         img_grayscale_float64 = img_grayscale_float.astype(np.float64)
 
@@ -664,7 +664,7 @@ class TestImageSimilarityMetrics:
 
     @pytest.mark.parametrize("metric", list(ALL_IMG_METRICS.keys()))
     def test_inconsistent_mask(self, metric):
-        """Test that the dimensions of the mask are consistent. If not, raises an exception """
+        """Test that the dimensions of the mask are consistent. If not, raises an exception"""
 
         img_true = np.zeros((20, 20, 20), dtype="float32")
         img_pred = np.zeros((10, 20, 20), dtype="float32")

--- a/tests/test_zoo.py
+++ b/tests/test_zoo.py
@@ -136,7 +136,7 @@ class TestControlPoints:
     """A collection of tests focused on the control_points approach."""
 
     def test_wrong_inputs_0(self):
-        """ Test that other types then np.ndarray lead to an error"""
+        """Test that other types then np.ndarray lead to an error"""
 
         shape = (40, 50)
         points = "fake"

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
     flake8 setup.py {[tox]source} tests
     isort --honor-noqa --profile=black --check setup.py {[tox]source} tests
     pydocstyle {[tox]source}
-    black -q --check setup.py {[tox]source} tests
+    black --check setup.py {[tox]source} tests
 
 [testenv:format]
 basepython = python3.7


### PR DESCRIPTION
`black` notices this, however, `pydocstyle` doesn't because it does not look into `tests`.