### PR TITLE
Add Python3.6 in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,11 +18,14 @@ jobs:
       matrix:
         os: [ubuntu-latest] # macos 11 is currently in preview, macos-latest == 1.10.15
         python-version: [
+          3.6,
           3.7,
           3.8,
           3.9,
         ]
         include:
+          - python-version: 3.6
+            tox-env: py36
           - python-version: 3.7
             tox-env: py37
           - python-version: 3.8


### PR DESCRIPTION
Python version `3.6` was not tested in the CI but accepted in the `setup.py`.