### PR TITLE
Create `GLOBAL_CACHE_FOLDER` if it doesn't exist

### DIFF
--- a/atlalign/base.py
+++ b/atlalign/base.py
@@ -52,7 +52,10 @@ from atlalign.zoo import (
     single_frequency,
 )
 
+# Set/create the default caching folder
 GLOBAL_CACHE_FOLDER = pathlib.Path.home() / ".atlalign"
+if not GLOBAL_CACHE_FOLDER.exists():
+    GLOBAL_CACHE_FOLDER.mkdir(parents=True)
 
 
 class DisplacementField:


### PR DESCRIPTION
Previously it was possible that `GLOBAL_CACHE_FOLDER` points to a folder  that doesn't exist. Now we always create it.

If `GLOBAL_CACHE_FOLDER` doesn't exit, then `atlalign.intensity.antspy_registration` will fail. Maybe other things too.

